### PR TITLE
タグ機能の実装

### DIFF
--- a/app/controllers/admin/spots_controller.rb
+++ b/app/controllers/admin/spots_controller.rb
@@ -39,11 +39,9 @@ class Admin::SpotsController < ApplicationController
   end
 
   def show
-
   end
 
   def edit
-
   end
 
   def update
@@ -66,11 +64,6 @@ class Admin::SpotsController < ApplicationController
 
   private
 
-  def if_not_admin
-    flash[:danger] = I18n.t('flash.permission_denied')
-    redirect_to root_path unless current_user.admin?
-  end
-
   def set_spot
     @spot = Spot.find(params[:id])
   end
@@ -78,5 +71,12 @@ class Admin::SpotsController < ApplicationController
   def spot_params
     params.require(:spot).permit(:name, :area, :address, :phone, :holiday,
         :sales_copy, :detail_description, :simple_description, :images_cache, {images: []})
+  end
+
+  def if_not_admin
+    unless current_user.admin? then
+      flash[:danger] = I18n.t('flash.permission_denied')
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/admin/spots_controller.rb
+++ b/app/controllers/admin/spots_controller.rb
@@ -17,7 +17,7 @@ class Admin::SpotsController < ApplicationController
   def confirm
     @spot = Spot.new(spot_params)
     if @spot.invalid?
-      flash[:danger] = I18n.t('flash.input_error')
+      flash[:danger] = t('flash.input_error')
       render :new
     end
   end
@@ -29,10 +29,10 @@ class Admin::SpotsController < ApplicationController
       render :new
     else
       if @spot.save
-        flash[:notice] = I18n.t('flash.registered_spot')
+        flash[:notice] = t('flash.registered_spot')
         redirect_to spots_path
       else
-        flash[:danger] = I18n.t('flash.input_error')
+        flash[:danger] = t('flash.input_error')
         render :new
       end
     end
@@ -46,7 +46,7 @@ class Admin::SpotsController < ApplicationController
 
   def update
     if @spot.update(spot_params)
-      flash[:notice] = I18n.t('flash.updated_spot')
+      flash[:notice] = t('flash.updated_spot')
       redirect_to spots_path
     else
       render 'edit'
@@ -55,7 +55,7 @@ class Admin::SpotsController < ApplicationController
 
   def destroy
     if @spot.destroy
-      flash[:notice] = I18n.t('flash.deleted_spot')
+      flash[:notice] = t('flash.deleted_spot')
       redirect_to spots_path
     else
       render 'edit'
@@ -75,7 +75,7 @@ class Admin::SpotsController < ApplicationController
 
   def if_not_admin
     unless current_user.admin? then
-      flash[:danger] = I18n.t('flash.permission_denied')
+      flash[:danger] = t('flash.permission_denied')
       redirect_to root_path
     end
   end

--- a/app/controllers/admin/spots_controller.rb
+++ b/app/controllers/admin/spots_controller.rb
@@ -69,8 +69,8 @@ class Admin::SpotsController < ApplicationController
   end
 
   def spot_params
-    params.require(:spot).permit(:name, :area, :address, :phone, :holiday,
-        :sales_copy, :detail_description, :simple_description, :images_cache, {images: []})
+    params.require(:spot).permit(:name, :area, :address, :phone, :holiday, :sales_copy,
+      :detail_description, :simple_description, :images_cache, {images: []}, {tag_ids: []})
   end
 
   def if_not_admin

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -17,7 +17,7 @@ class Admin::TagsController < ApplicationController
   def confirm
     @tag = Tag.new(tag_params)
     if @tag.invalid?
-      flash[:danger] = I18n.t('flash.input_error')
+      flash[:danger] = t('flash.input_error')
       render :new
     end
   end
@@ -28,10 +28,10 @@ class Admin::TagsController < ApplicationController
       render :new
     else
       if @tag.save
-        flash[:notice] = I18n.t('flash.created_tag')
+        flash[:notice] = t('flash.created_tag')
         redirect_to admin_tags_path
       else
-        flash[:danger] = I18n.t('flash.input_error')
+        flash[:danger] = t('flash.input_error')
         render :new
       end
     end
@@ -42,20 +42,20 @@ class Admin::TagsController < ApplicationController
 
   def update
     if @tag.update(tag_params)
-      flash[:notice] = I18n.t('flash.edited_tag')
+      flash[:notice] = t('flash.edited_tag')
       redirect_to admin_tags_path
     else
-      flash[:danger] = I18n.t('flash.edited_tag_failed')
+      flash[:danger] = t('flash.edited_tag_failed')
       render :edit
     end
   end
 
   def destroy
     if @tag.destroy
-      flash[:notice] = I18n.t('flash.deleted_tag')
+      flash[:notice] = t('flash.deleted_tag')
       redirect_to admin_tags_path
     else
-      flash[:danger] = I18n.t('flash.delete_tag_failed')
+      flash[:danger] = t('flash.delete_tag_failed')
       redirect_to admin_tags_path
     end
   end
@@ -72,7 +72,7 @@ class Admin::TagsController < ApplicationController
 
   def if_not_admin
     unless current_user.admin? then
-      flash[:danger] = I18n.t('flash.permission_denied')
+      flash[:danger] = t('flash.permission_denied')
       redirect_to root_path
     end
   end

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -1,0 +1,80 @@
+class Admin::TagsController < ApplicationController
+  before_action :if_not_admin
+  before_action :set_tag, only: %i[show edit update destroy]
+
+  def index
+    @tags = Tag.all
+  end
+
+  def new
+    if params[:back]
+      @tag = Tag.new(tag_params)
+    else
+      @tag = Tag.new
+    end
+  end
+
+  def confirm
+    @tag = Tag.new(tag_params)
+    if @tag.invalid?
+      flash[:danger] = I18n.t('flash.input_error')
+      render :new
+    end
+  end
+
+  def create
+    @tag = Tag.new(tag_params)
+    if params[:back]
+      render :new
+    else
+      if @tag.save
+        flash[:notice] = I18n.t('flash.created_tag')
+        redirect_to admin_tags_path
+      else
+        flash[:danger] = I18n.t('flash.input_error')
+        render :new
+      end
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @tag.update(tag_params)
+      flash[:notice] = I18n.t('flash.edited_tag')
+      redirect_to admin_tags_path
+    else
+      flash[:danger] = I18n.t('flash.edited_tag_failed')
+      render :edit
+    end
+  end
+
+  def destroy
+    if @tag.destroy
+      flash[:notice] = I18n.t('flash.deleted_tag')
+      redirect_to admin_tags_path
+    else
+      flash[:danger] = I18n.t('flash.delete_tag_failed')
+      redirect_to admin_tags_path
+    end
+  end
+
+  private
+
+  def set_tag
+    @tag = Tag.find(params[:id])
+  end
+
+  def tag_params
+    params.require(:tag).permit(:name)
+  end
+
+  def if_not_admin
+    unless current_user.admin? then
+      flash[:danger] = I18n.t('flash.permission_denied')
+      redirect_to root_path
+    end
+  end
+
+end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -4,6 +4,19 @@ class SpotsController < ApplicationController
     @spots = Spot.all
   end
 
+  def search
+    @spots = Spot.all
+    key_tag_id = params[:key_tag_id]
+
+    if key_tag_id.present?
+      @spots = @spots.tag_search(key_tag_id.to_i)
+    end
+
+    #pagination
+    #@spots = @spots.page(params[:page])
+    render "index"
+  end
+
   def show
     @spot = Spot.find(params[:id])
   end

--- a/app/helpers/spots_helper.rb
+++ b/app/helpers/spots_helper.rb
@@ -1,6 +1,6 @@
 module SpotsHelper
-  def choose_new_or_edit
-    if action_name == "new" || action_name == "create"
+  def spot_choose_new_or_edit
+    if action_name == "new" || action_name == "confirm"
       confirm_admin_spots_path
     elsif action_name == "edit"
       admin_spot_path

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,0 +1,14 @@
+module TagsHelper
+  def tag_choose_new_or_edit
+    if action_name == "new" || action_name == "confirm"
+      puts
+      puts
+      puts "+++++++++++++"
+      puts confirm_admin_tags_path
+      puts
+      confirm_admin_tags_path
+    elsif action_name == "edit"
+      admin_tag_path
+    end
+  end
+end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,11 +1,6 @@
 module TagsHelper
   def tag_choose_new_or_edit
     if action_name == "new" || action_name == "confirm"
-      puts
-      puts
-      puts "+++++++++++++"
-      puts confirm_admin_tags_path
-      puts
       confirm_admin_tags_path
     elsif action_name == "edit"
       admin_tag_path

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,7 +1,7 @@
 class Spot < ApplicationRecord
   mount_uploaders :images, ImageUploader
   has_many :taggings, dependent: :destroy
-  has_many :with_tag, through: :taggings, source: :tag
+  has_many :tags, through: :taggings
 
   enum area: { 県北: 1, 県央: 2, 県西: 3, 県南: 4, 鹿行: 5 }
 

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,5 +1,7 @@
 class Spot < ApplicationRecord
   mount_uploaders :images, ImageUploader
+  has_many :taggings, dependent: :destroy
+  has_many :with_tag, through: :taggings, source: :tag
 
   enum area: { 県北: 1, 県央: 2, 県西: 3, 県南: 4, 鹿行: 5 }
 

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -13,4 +13,6 @@ class Spot < ApplicationRecord
   validates :sales_copy, length: { maximum: 255 }
   validates :detail_description, presence: true
   validates :simple_description, length: { maximum: 255 }
+
+  scope :tag_search, -> (key_tag_id){ where(id: Tagging.where(tag_id: key_tag_id).pluck(:spot_id)) }
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -3,7 +3,7 @@ class Spot < ApplicationRecord
 
   enum area: { 県北: 1, 県央: 2, 県西: 3, 県南: 4, 鹿行: 5 }
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
   validates :area, presence: true, length: { maximum: 10 }
   validates :address, presence: true, length: { maximum: 160 }
   validates :phone, length: { maximum: 21 }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,3 @@
 class Tag < ApplicationRecord
+  validates :name, uniqueness: true
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,6 @@
 class Tag < ApplicationRecord
+  has_many :taggings, dependent: :destroy
+  has_many :tagged_spots, through: :taggings, source: :spot
+
   validates :name, uniqueness: true
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,6 @@
 class Tag < ApplicationRecord
   has_many :taggings, dependent: :destroy
-  has_many :tagged_spots, through: :taggings, source: :spot
+  has_many :spots, through: :taggings
 
   validates :name, uniqueness: true
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,4 @@
+class Tagging < ApplicationRecord
+  belongs_to :spot
+  belongs_to :tag
+end

--- a/app/views/admin/spots/_form.html.erb
+++ b/app/views/admin/spots/_form.html.erb
@@ -1,14 +1,4 @@
 <% content_for(:title, form_title) %>
-
-
-<% puts %>
-<% puts "+++++++++++++++++++++++++++" %>
-<% p spot_choose_new_or_edit %>
-<% puts "+++++++++++++++++++++++++++" %>
-<% p @spot %>
-<% puts "+++++++++++++++++++++++++++" %>
-
-
 <%= form_with(model: @spot, local: true, url: spot_choose_new_or_edit ) do |f| %>
   <% if @spot.errors.any? %>
     <div>
@@ -52,6 +42,14 @@
   </div>
   <div class="field">
     <%= f.text_area :simple_description, size: "50x2", placeholder:t('activerecord.attributes.spot.simple_description') %>
+  </div>
+  <div class="field">
+    <%= f.label :tag_name, t('activerecord.attributes.tag.name') %>
+    <ul>
+      <%= f.collection_check_boxes(:tag_ids, Tag.all, :id, :name) do |b| %>
+        <li><%= b.check_box %><span class="badge bg-info mx-1 pb-0"><%= b.label %></span></li>
+      <% end %>
+    </ul>
   </div>
   <div class="actions">
     <%= f.submit t('views.button.confirm') %>

--- a/app/views/admin/spots/_form.html.erb
+++ b/app/views/admin/spots/_form.html.erb
@@ -1,5 +1,15 @@
 <% content_for(:title, form_title) %>
-<%= form_with(model: @spot, local: true, url: choose_new_or_edit ) do |f| %>
+
+
+<% puts %>
+<% puts "+++++++++++++++++++++++++++" %>
+<% p spot_choose_new_or_edit %>
+<% puts "+++++++++++++++++++++++++++" %>
+<% p @spot %>
+<% puts "+++++++++++++++++++++++++++" %>
+
+
+<%= form_with(model: @spot, local: true, url: spot_choose_new_or_edit ) do |f| %>
   <% if @spot.errors.any? %>
     <div>
       <h5><%= t('errors.messages.title') %></h5>

--- a/app/views/admin/spots/confirm.html.erb
+++ b/app/views/admin/spots/confirm.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, "確認") %>
 <h2>Confirm</h2>
-<%= form_with(model: @spot, local: true, url: spots_path ) do |f| %>
+<%= form_with(model: @spot, local: true, url: admin_spots_path ) do |f| %>
   <%= f.hidden_field :name %>
   <%= f.hidden_field :images_cache %>
   <%= f.hidden_field :area %>

--- a/app/views/admin/spots/confirm.html.erb
+++ b/app/views/admin/spots/confirm.html.erb
@@ -10,6 +10,7 @@
   <%= f.hidden_field :sales_copy %>
   <%= f.hidden_field :detail_description %>
   <%= f.hidden_field :simple_description %>
+  <%= f.hidden_field :tag_ids %>
   <div>Name: <%= @spot.name %></div>
   <div>Image:
     <% @spot.images.each do |image| %>
@@ -23,6 +24,14 @@
   <div>Sales Copy: <%= @spot.sales_copy %></div>
   <div>Detail Description: <%= @spot.detail_description %></div>
   <div>Simple Description: <%= @spot.simple_description %></div>
+  <div>Tags: </div>
+  <div>
+    <ul>
+      <% @spot.tags.each do |tag| %>
+        <li><span class="badge bg-info"><%= tag.name %></span></li>
+      <% end %>
+    </ul>
+  </div>
   <div>
     <%= f.submit "登録" %>
   </div>
@@ -37,6 +46,7 @@
   <%= f.hidden_field :sales_copy %>
   <%= f.hidden_field :detail_description %>
   <%= f.hidden_field :simple_description %>
+  <%= f.hidden_field :tag_ids %>
   <div>
     <%= f.submit "戻る", name: 'back' %>
   </div>

--- a/app/views/admin/spots/confirm.html.erb
+++ b/app/views/admin/spots/confirm.html.erb
@@ -10,7 +10,9 @@
   <%= f.hidden_field :sales_copy %>
   <%= f.hidden_field :detail_description %>
   <%= f.hidden_field :simple_description %>
-  <%= f.hidden_field :tag_ids %>
+  <% @spot.tags.each do |tag| %>
+    <%= f.hidden_field :tag_ids, multiple: true, value: tag.id %>
+<% end %>
   <div>Name: <%= @spot.name %></div>
   <div>Image:
     <% @spot.images.each do |image| %>
@@ -46,7 +48,9 @@
   <%= f.hidden_field :sales_copy %>
   <%= f.hidden_field :detail_description %>
   <%= f.hidden_field :simple_description %>
-  <%= f.hidden_field :tag_ids %>
+  <% @spot.tags.each do |tag| %>
+    <%= f.hidden_field :tag_ids, multiple: true, value: tag.id %>
+<% end %>
   <div>
     <%= f.submit "戻る", name: 'back' %>
   </div>

--- a/app/views/admin/spots/edit.html.erb
+++ b/app/views/admin/spots/edit.html.erb
@@ -1,0 +1,7 @@
+<h3><%= t('views.messages.edit_spot') %></h3>
+<div>
+  <%= render partial: "form", locals: { form_title: t('views.messages.edit_spot')} %>
+</div>
+<div>
+<%= link_to "戻る", root_path  %>
+</div>

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -1,18 +1,4 @@
 <% content_for(:title, form_title) %>
-
-
-
-
-<% puts %>
-<% puts "+++++++++++++++++++++++++++" %>
-<% puts tag_choose_new_or_edit %>
-<% puts "+++++++++++++++++++++++++++" %>
-<% puts %>
-
-
-
-
-
 <%= form_with(model: @tag, local: true, url: tag_choose_new_or_edit ) do |f| %>
   <% if @tag.errors.any? %>
     <div>

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -1,0 +1,35 @@
+<% content_for(:title, form_title) %>
+
+
+
+
+<% puts %>
+<% puts "+++++++++++++++++++++++++++" %>
+<% puts tag_choose_new_or_edit %>
+<% puts "+++++++++++++++++++++++++++" %>
+<% puts %>
+
+
+
+
+
+<%= form_with(model: @tag, local: true, url: tag_choose_new_or_edit ) do |f| %>
+  <% if @tag.errors.any? %>
+    <div>
+      <h5><%= t('errors.messages.title') %></h5>
+      <div>
+        <ul>
+          <% @tag.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+  <div class="field">
+    <%= f.text_field :name, size: 54, placeholder:t('activerecord.attributes.tag.name') %>
+  </div>
+  <div class="actions">
+    <%= f.submit t('views.button.confirm') %>
+  </div>
+<% end %>

--- a/app/views/admin/tags/confirm.html.erb
+++ b/app/views/admin/tags/confirm.html.erb
@@ -1,0 +1,15 @@
+<% content_for(:title, "確認") %>
+<h2>Confirm</h2>
+<%= form_with(model: @tag, local: true, url: admin_tags_path ) do |f| %>
+  <%= f.hidden_field :name %>
+  <div>Name: <%= @tag.name %></div>
+  <div>
+    <%= f.submit "登録" %>
+  </div>
+<% end %>
+<%= form_with(model: @tag, url:new_admin_tag_path, local:true, method:"get") do |f| %>
+  <%= f.hidden_field :name %>
+  <div>
+    <%= f.submit "戻る", name: 'back' %>
+  </div>
+<% end %>

--- a/app/views/admin/tags/edit.html.erb
+++ b/app/views/admin/tags/edit.html.erb
@@ -1,0 +1,7 @@
+<h3><%= t('views.messages.edit_tag') %></h3>
+<div>
+  <%= render partial: "form", locals: { form_title: t('views.messages.edit_tag')} %>
+</div>
+<div>
+<%= link_to "タグ一覧", admin_tags_path  %>
+</div>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -1,5 +1,5 @@
 <div class="title_area">
-  <h1><%= I18n.t('views.messages.tags_index') %></h1>
+  <h1><%= t('views.messages.tags_index') %></h1>
 </div>
 <% @tags.each do |tag| %>
   <div>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -1,0 +1,8 @@
+<div class="title_area">
+  <h1><%= I18n.t('views.messages.tags_index') %></h1>
+</div>
+<% @tags.each do |tag| %>
+  <div>
+    <%= tag.name %>
+  </div>
+<% end %>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -4,5 +4,13 @@
 <% @tags.each do |tag| %>
   <div>
     <%= tag.name %>
+    <ul>
+      <li>
+        <%= link_to t('views.button.edit'), edit_admin_tag_path(tag.id), id: "edit_#{tag.id}" %>
+      </li>
+      <li>
+        <%= link_to t('views.button.delete'), admin_tag_path(tag.id), id: "delete_#{tag.id}", method: :delete, data: { confirm: '本当に削除しますか？' } %>
+      </li>
+    </ul>
   </div>
 <% end %>

--- a/app/views/admin/tags/new.html.erb
+++ b/app/views/admin/tags/new.html.erb
@@ -1,0 +1,7 @@
+<h3><%= t('views.messages.create_tag') %></h3>
+<div>
+  <%= render partial: "form", locals: { form_title: t('views.messages.create_tag')} %>
+</div>
+<div>
+<%= link_to "戻る", root_path  %>
+</div>

--- a/app/views/admin/tags/new.html.erb
+++ b/app/views/admin/tags/new.html.erb
@@ -3,5 +3,5 @@
   <%= render partial: "form", locals: { form_title: t('views.messages.create_tag')} %>
 </div>
 <div>
-<%= link_to "戻る", root_path  %>
+<%= link_to "タグ一覧", admin_tags_path  %>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,6 +7,7 @@
       <% if user_signed_in? %>
         <% if current_user.try(:admin?) %>
           <li><%= link_to "スポット登録", new_admin_spot_path %></li>
+          <li><%= link_to "タグ登録", new_admin_tag_path %></li>
         <% end %>
         <%# <li><%= link_to "プロフィール", user_path(current_user.id)</li> %>
         <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -12,6 +12,13 @@
         <% end %>
       <% end %>
       <div><%= spot.simple_description %></div>
+      <div>
+        <ul>
+          <% spot.tags.each do |tag| %>
+            <li><span class="badge bg-info"><%= tag.name %></span></li>
+          <% end %>
+        </ul>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,4 +1,15 @@
 <% content_for(:title, 'chokkura') %>
+<div>
+  <h5> タグで絞り込む</h5>
+  <%= form_with url: search_spots_path, method: :get, local: true do |f| %>
+    <div>
+      <%= f.select :key_tag_id, Tag.all.collect { |l| [l.name, l.id] }, { include_blank: "タグを選択する" }, value: @key_tag_id  %>
+    </div>
+    <div>
+      <%= f.submit t('views.button.search'), class:"form-control form-control-sm" %>
+    </div>
+  <% end %>
+</div>
 <% @spots.each do |spot| %>
   <div style="border: 1px solid black;" class="mb-2">
     <div><%= spot.area %></div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -8,3 +8,14 @@
   <% end %>
 </div>
 <%= link_to 'Back', spots_path %>
+
+  <div>
+    <ul>
+      <% if user_signed_in? %>
+        <% if current_user.try(:admin?) %>
+          <li><%= link_to "編集", edit_admin_spot_path %></li>
+          <li><%= link_to "削除", admin_spot_path(@spot.id), method: :delete, data: { confirm: '本当に削除しますか？' } %></li>
+        <% end %>
+      <% end %>
+    </ul>
+  </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,8 @@ ja:
   activerecord:
     models:
       spot: 観光スポット
+      tag: タグ
+      user: ユーザ
     attributes:
       spot:
         name: スポット名
@@ -14,8 +16,26 @@ ja:
         sales_copy: "セールスコピー"
         detail_description: "詳細説明"
         simple_description: "簡易説明"
-        created_at: 作成日
-        updated_at: 更新日
+        created_at: "スポット作成日時"
+        updated_at: "スポット更新日時"
+      tag:
+        name: タグ名
+        created_at: "タグ作成日時"
+        updated_at: "タグ更新日時"
+      user:
+        email: "メールアドレス"
+        encrypted_password: "パスワード"
+        reset_password_token: "パスワードリセット用トークン"
+        reset_password_sent_at: "パスワードリセット用メールの送信日時"
+        remember_created_at: "ログイン保持機能を有効化した日時"
+        sign_in_count: "ログイン回数"
+        current_sign_in_at: "直近でログインした日時"
+        last_sign_in_at: "最後にログインした日時"
+        current_sign_in_ip: "直近でログインしたIPアドレス"
+        last_sign_in_ip: "最後にログインしたIPアドレス"
+        created_at: "アカウント作成日時"
+        updated_at: "アカウント更新日時"
+        admin: "管理者権限"
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'
@@ -210,6 +230,9 @@ ja:
       register_spot: '観光スポットの登録'
       edit_spot: '観光スポットの編集'
       select_area: 'エリアの選択'
+      create_tag: 'タグの新規登録'
+      edit_tag: 'タグの編集'
+      tags_index: 'タグ一覧'
       want_to_delete?: '削除してもよろしいですか？'
     button:
       submit: '登録する'
@@ -224,3 +247,8 @@ ja:
     registered_spot: '観光スポットを登録しました'
     updated_spot: '観光スポットを更新しました'
     deleted_spot: '観光スポットを削除しました'
+    created_tag: 'タグを新規作成しました'
+    edited_tag: 'タグを編集しました'
+    edited_tag_failed: 'タグの編集に失敗しました'
+    deleted_tag: 'タグを削除しました'
+    delete_tag_failed: 'タグの削除に失敗しました'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@ Rails.application.routes.draw do
 
   root to: 'spots#index'
 
-  resources :spots, only: [:index, :show]
+  resources :spots, only: [:index, :show] do
+    collection do
+      get :search
+    end
+  end
 
   namespace :admin do
     resources :spots, only: [:new, :create, :edit, :update, :destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,11 @@ Rails.application.routes.draw do
         post :confirm
       end
     end
+    resources :tags, only: [:index, :new, :create, :edit, :destroy] do
+      collection do
+        post :confirm
+      end
+    end
   end
 
   if Rails.env.development?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,12 @@ Rails.application.routes.draw do
   resources :spots, only: [:index, :show]
 
   namespace :admin do
-    resources :spots, only: [:new, :create, :edit, :destroy] do
+    resources :spots, only: [:new, :create, :edit, :update, :destroy] do
       collection do
         post :confirm
       end
     end
-    resources :tags, only: [:index, :new, :create, :edit, :destroy] do
+    resources :tags, only: [:index, :new, :create, :edit, :update, :destroy] do
       collection do
         post :confirm
       end

--- a/db/migrate/20230612174427_create_tags.rb
+++ b/db/migrate/20230612174427_create_tags.rb
@@ -1,0 +1,8 @@
+class CreateTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230612195440_add_index_to_tags_name.rb
+++ b/db/migrate/20230612195440_add_index_to_tags_name.rb
@@ -1,0 +1,5 @@
+class AddIndexToTagsName < ActiveRecord::Migration[6.1]
+  def change
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/migrate/20230613055350_create_taggings.rb
+++ b/db/migrate/20230613055350_create_taggings.rb
@@ -1,0 +1,10 @@
+class CreateTaggings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :taggings do |t|
+      t.references :spot, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_12_174427) do
+ActiveRecord::Schema.define(version: 2023_06_12_195440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2023_06_12_174427) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_12_044546) do
+ActiveRecord::Schema.define(version: 2023_06_12_174427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,12 @@ ActiveRecord::Schema.define(version: 2023_06_12_044546) do
     t.string "sales_copy"
     t.text "detail_description", null: false
     t.string "simple_description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_12_195440) do
+ActiveRecord::Schema.define(version: 2023_06_13_055350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,15 @@ ActiveRecord::Schema.define(version: 2023_06_12_195440) do
     t.string "simple_description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "spot_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["spot_id"], name: "index_taggings_on_spot_id"
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
   end
 
   create_table "tags", force: :cascade do |t|
@@ -54,4 +63,6 @@ ActiveRecord::Schema.define(version: 2023_06_12_195440) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "taggings", "spots"
+  add_foreign_key "taggings", "tags"
 end

--- a/spec/factories/taggings.rb
+++ b/spec/factories/taggings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :tagging do
+    spot { nil }
+    tag { nil }
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/tagging_spec.rb
+++ b/spec/models/tagging_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Tagging, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
#5

更新内容
- 管理者権限によるTagの新規登録、編集、削除をできるようにした
- 中間テーブルTaggingを用意して、SpotとTagの多対多による関連付けを行った
- Spot登録、編集時にTagを付けられるようにした
- Spot一覧ページにおいてTagを使った絞り込みをできるようにした