### PR TITLE
管理者ページの実装

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,58 @@
+class Admin::UsersController < ApplicationController
+  before_action :if_not_admin
+  skip_before_action :if_not_admin, only: [:after_ensure]
+  before_action :set_user, only: [:show, :control]
+
+  def index
+    @users = User.all
+  end
+
+  def show
+  end
+
+  def control
+    case params[:act]
+    when "grant"
+      if @user[:admin] == true
+        flash[:danger] = t('views.messages.already_admin')
+      elsif @user.update_attribute(:admin, true)
+        flash[:notice] = t('views.messages.grant_admin')
+      else
+        flash[:danger] = t('views.messages.change_admin_failed')
+      end
+      redirect_to admin_users_path
+    when "ensure"
+      if @user[:admin] == false
+        flash[:danger] = t('views.messages.already_not_admin')
+        redirect_to admin_users_path
+      elsif @user.update_attribute(:admin, false)
+        after_ensure
+      else
+        flash[:danger] = t('views.messages.change_admin_failed')
+        redirect_to admin_users_path
+      end
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def if_not_admin
+    unless current_user.admin? then
+      flash[:danger] = t('flash.permission_denied')
+      redirect_to root_path
+    end
+  end
+
+  def after_ensure
+    if @user.id == current_user.id && @user.admin == false
+      redirect_to :root
+    else
+      redirect_to admin_users_path
+    end
+    flash[:notice] = I18n.t('views.messages.ensure_admin')
+  end
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,13 @@
+class AdminController < ApplicationController
+  before_action :if_not_admin
+
+  def index
+  end
+
+  def if_not_admin
+    unless current_user.admin? then
+      flash[:danger] = t('flash.permission_denied')
+      redirect_to root_path
+    end
+  end
+end

--- a/app/javascript/stylesheets/style.css
+++ b/app/javascript/stylesheets/style.css
@@ -1,3 +1,52 @@
 .main-wrapper {
-  margin-top: 0px;
+  margin-top: 40px;
+}
+
+.title_area h2 {
+  text-align: center;
+}
+
+.admin_area table {
+  margin: 40px auto;
+  table-layout: auto;
+  width: 100%;
+  max-width: 900px;
+}
+
+.admin_area th {
+  color: #333333;
+  font-size: 0.8rem;
+  text-align: center;
+  padding: 8px;
+  border-top: 1px solid #0c0000;
+  border-bottom: 1px solid #0c0000;
+}
+
+.admin_area th:last-child {
+  width: 250px;
+}
+
+.admin_area td {
+  font-size: 0.8rem;
+  padding: 6px 10px;
+  text-align: center;
+  border-top: 1px solid #cccccc;
+}
+
+.admin_control_button {
+  margin-bottom: 20px;
+  width: 100%;
+  height: 20px;
+}
+
+.admin_control_button ul {
+  margin: 0;
+  padding: 0;
+  float: right;
+}
+
+.admin_control_button li {
+  float: left;
+  padding: 8px;
+  list-style: none;
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  before_update :not_change_last_admin
+  before_destroy :not_delete_last_admin
+
   has_many :favorites, dependent: :destroy
   has_many :favorite_spots, through: :favorites, source: :spot
 
@@ -12,4 +15,15 @@ class User < ApplicationRecord
     茨城県:1,栃木県:2,群馬県:3,埼玉県:4,千葉県:5,東京都:6,神奈川県:7
   }
 
+# enum admin: { あり: true, なし: false }
+
+  private
+
+  def not_change_last_admin
+    throw :abort if User.where(admin: true).count == 1 && self.will_save_change_to_admin?(from: "あり", to: "なし")
+  end
+
+  def not_delete_last_admin
+    throw :abort if User.where(admin: true).count == 1 && self.admin == "あり"
+  end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,0 +1,29 @@
+<% content_for(:title, t('views.messages.admin_menu')) %>
+<div class="container justify-content-center">
+  <div class="title_area">
+    <h2><%= t('views.messages.admin_menu') %></h2>
+  </div>
+  <div class="row mt-4">
+    <div class="col-4">
+      <h5><%= t('activerecord.models.user') %></h5>
+      <ul>
+        <li><%= link_to t('views.messages.watch_users_index'), admin_users_path %></li>
+        <li><%= t('views.messages.create_user') %></li>
+      </ul>
+    </div>
+    <div class="col-4">
+      <h5><%= t('activerecord.models.spot') %></h5>
+      <ul>
+        <li><%= link_to t('views.messages.watch_spots_index'), admin_spots_path %></li>
+        <li><%= link_to t('views.messages.create_spot'), new_admin_spot_path %></li>
+      </ul>
+    </div>
+    <div class="col-4">
+      <h5><%= t('activerecord.models.tag') %></h5>
+      <ul>
+        <li><%= link_to t('views.messages.watch_tags_index'), admin_tags_path %></li>
+        <li><%= link_to t('views.messages.create_tag'), new_admin_tag_path %></li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/spots/edit.html.erb
+++ b/app/views/admin/spots/edit.html.erb
@@ -3,5 +3,5 @@
   <%= render partial: "form", locals: { form_title: t('views.messages.edit_spot')} %>
 </div>
 <div>
-<%= link_to "戻る", root_path  %>
+<%= link_to t('views.messages.back'), admin_spots_path  %>
 </div>

--- a/app/views/admin/spots/index.html.erb
+++ b/app/views/admin/spots/index.html.erb
@@ -1,0 +1,38 @@
+<% content_for(:title, t('views.messages.spots_index')) %>
+<div class="title_area">
+  <h2><%= t('views.messages.spots_index') %></h2>
+</div>
+<div class="admin_area">
+  <table>
+    <tr>
+      <th><%= t("activerecord.attributes.spot.id") %></th>
+      <th><%= t("activerecord.attributes.spot.name") %></th>
+      <th><%= t("activerecord.attributes.spot.area") %></th>
+      <th><%= t("views.messages.with_tags_count") %></th>
+      <th><%= t("views.messages.control") %></th>
+    </tr>
+    <% @spots.each do |spot| %>
+      <tr>
+        <td><%= spot.id %></td>
+        <td><%= spot.name %></td>
+        <td><%= spot.area %></td>
+        <td><%= spot.tags.count %></td>
+        <td>
+          <div class="admin_control_button">
+            <ul>
+              <li>
+                <%= link_to t('views.button.show'), spot_path(spot.id), id: "show_#{spot.id}", class: "btn btn-light btn-sm mb-0" %>
+              </li>
+              <li>
+                <%= link_to t('views.button.edit'), edit_admin_spot_path(spot.id), id: "edit_#{spot.id}", class: "btn btn-light btn-sm mb-0" %>
+              </li>
+              <li>
+                <%= link_to t('views.button.delete'), admin_spot_path(spot.id), id: "delete_#{spot.id}", method: :delete, class: "btn btn-danger btn-sm mb-0", data: { confirm: t('views.messages.want_to_delete?') } %>
+              </li>
+            </ul>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+</div>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -1,16 +1,33 @@
+<% content_for(:title, t('views.messages.tags_index')) %>
 <div class="title_area">
-  <h1><%= t('views.messages.tags_index') %></h1>
+  <h2><%= t('views.messages.tags_index') %></h2>
 </div>
-<% @tags.each do |tag| %>
-  <div>
-    <%= tag.name %>
-    <ul>
-      <li>
-        <%= link_to t('views.button.edit'), edit_admin_tag_path(tag.id), id: "edit_#{tag.id}" %>
-      </li>
-      <li>
-        <%= link_to t('views.button.delete'), admin_tag_path(tag.id), id: "delete_#{tag.id}", method: :delete, data: { confirm: '本当に削除しますか？' } %>
-      </li>
-    </ul>
-  </div>
-<% end %>
+<div class="admin_area">
+<table>
+  <tr>
+    <th><%= t("activerecord.attributes.tag.id") %></th>
+    <th><%= t("activerecord.attributes.tag.name") %></th>
+    <th><%= t("views.messages.tagged_spot_count") %></th>
+    <th><%= t("views.messages.control") %></th>
+  </tr>
+  <% @tags.each do |tag| %>
+    <tr>
+      <td><%= tag.id %></td>
+      <td><%= tag.name %></td>
+      <td><%= tag.spots.count %></td>
+      <td>
+        <div class="admin_control_button">
+          <ul>
+            <li>
+              <%= link_to t('views.button.edit'), edit_admin_tag_path(tag.id), id: "edit_#{tag.id}", class: "btn btn-light btn-sm mb-0" %>
+            </li>
+            <li>
+              <%= link_to t('views.button.delete'), admin_tag_path(tag.id), id: "delete_#{tag.id}", method: :delete, class: "btn btn-danger btn-sm mb-0", data: { confirm: t('views.messages.want_to_delete?') } %>
+            </li>
+          </ul>
+        </div>
+      </td>
+    </tr>
+  <% end %>
+</table>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,46 @@
+<% content_for(:title, t('views.messages.users_index')) %>
+<div class="title_area">
+<h2><%= t('views.messages.users_index') %></h2>
+</div>
+<div class="admin_area">
+<table>
+    <tr>
+      <th><%= t("activerecord.attributes.user.id") %></th>
+      <th><%= t("activerecord.attributes.user.name") %></th>
+      <th><%= t("activerecord.attributes.user.email") %></th>
+      <th><%= t("activerecord.attributes.user.admin") %></th>
+      <th><%= t("views.messages.control") %></th>
+    </tr>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.id %></td>
+        <% if user.id == current_user.id %>
+          <td><strong><%= user.name %></strong></td>
+        <% else %>
+          <td><%= user.name %></td>
+        <% end %>
+        <td><%= user.email %></td>
+        <td><%= user.admin %></td>
+        <td>
+          <div class="admin_control_button">
+            <ul>
+              <li>
+                <% if user.admin? %>
+                  <%= link_to t('views.button.ensure_admin'), control_admin_user_path(user.id, act: "ensure"), id: "ensure_#{user.id}", class: "btn btn-light btn-sm mb-0" %>
+                <% else %>
+                  <%= link_to t('views.button.grant_admin'), control_admin_user_path(user.id, act: "grant"), id: "grant_#{user.id}", class: "btn btn-light btn-sm mb-0" %>
+                <% end %>
+              </li>
+              <li>
+                <%= link_to t('views.button.show'), user_path(user.id), id: "show_#{user.id}", class: "btn btn-light btn-sm mb-0" %>
+              </li>
+              <li>
+                <%= link_to t('views.button.delete'), admin_user_path(user.id), id: "delete_#{user.id}", method: :delete, class: "btn btn-danger btn-sm mb-0", data: { confirm: '本当に削除しますか？' } %>
+              </li>
+            </ul>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+</div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#show</h1>
+<p>Find me in app/views/admin/users/show.html.erb</p>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -6,15 +6,13 @@
     <ul>
       <% if user_signed_in? %>
         <li><strong><%= link_to current_user.name, user_path(current_user.id) %></strong></li>
-        <% if current_user.try(:admin?) %>
-          <li><%= link_to "スポット登録", new_admin_spot_path %></li>
-          <li><%= link_to "タグ登録", new_admin_tag_path %></li>
+        <% if current_user.admin? %>
+          <li><%= link_to t('views.messages.admin_menu'), admin_index_path %></li>
         <% end %>
-        <%# <li><%= link_to "プロフィール", user_path(current_user.id)</li> %>
-        <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
+        <li><%= link_to t('views.messages.logout'), destroy_user_session_path, method: :delete %></li>
       <% else %>
-        <li><%= link_to "サインアップ", new_user_registration_path %></li>
-        <li><%= link_to "ログイン", new_user_session_path %></li>
+        <li><%= link_to t('views.messages.signup'), new_user_registration_path %></li>
+        <li><%= link_to t('views.messages.login'), new_user_session_path %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, @spot.name) %>
 <div id="notice"><%= notice %></div>
 <div>
   <h4><%= @spot.name %></h4>
@@ -19,11 +20,11 @@
 
 <script>
   let map
-  
+
   function initMap(){
     geocoder = new google.maps.Geocoder()
     var test ={lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>};
-  
+
     map = new google.maps.Map(document.getElementById('map'), {
       center: test,
       zoom: 15,
@@ -33,7 +34,7 @@
     var infowindow = new google.maps.InfoWindow({
       content: contentString
     });
-  
+
     marker = new google.maps.Marker({
       position:  test,
       map: map,

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,7 @@
+<% content_for(:title, @user.name) %>
 <h4><%= @user.name %>のページ</h4>
 <div>
+  
   <h5>ユーザ情報</h5>
   <ul>
     <li>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,12 +2,13 @@
 ja:
   activerecord:
     models:
-      spot: 観光スポット
-      tag: タグ
-      user: ユーザ
+      spot: "観光スポット"
+      tag: "タグ"
+      user: "ユーザ"
     attributes:
       spot:
-        name: スポット名
+        id: "ID"
+        name: "スポット名"
         images: "スポットイメージ"
         area: "所在エリア"
         address: "住所"
@@ -19,10 +20,12 @@ ja:
         created_at: "スポット作成日時"
         updated_at: "スポット更新日時"
       tag:
-        name: タグ名
+        id: "ID"
+        name: "タグ名"
         created_at: "タグ作成日時"
         updated_at: "タグ更新日時"
       user:
+        id: "ID"
         name: "氏名"
         email: "メールアドレス"
         location: "所在地"
@@ -229,13 +232,34 @@ ja:
     pm: 午後
   views:
     messages:
+      spots_index: '観光スポット一覧'
       register_spot: '観光スポットの登録'
       edit_spot: '観光スポットの編集'
       select_area: 'エリアの選択'
       create_tag: 'タグの新規登録'
       edit_tag: 'タグの編集'
       tags_index: 'タグ一覧'
+      users_index: 'ユーザ一覧'
+      admin_menu: '管理者メニュー'
       want_to_delete?: '削除してもよろしいですか？'
+      tagged_spot_count: '紐付けスポット数'
+      with_tags_count: '紐付けタグ数'
+      watch_users_index: 'ユーザ一覧を見る'
+      create_user: 'ユーザを追加する'
+      watch_spots_index: 'スポット一覧を見る'
+      create_spot: 'スポットを追加する'
+      watch_tags_index: 'タグ一覧を見る'
+      create_tag: 'タグを追加する'
+      signup: 'ユーザ登録'
+      login: 'ログイン'
+      logout: 'ログアウト'
+      control: '操作'
+      back: '戻る'
+      grant_admin: "管理者権限を付与しました"
+      ensure_admin: "管理者権限を抹消しました"
+      already_admin: "すでに管理者権限があります"
+      already_not_admin: "すでに管理者権限はありません"
+      change_admin_failed: "管理者権限の変更に失敗しました"
     button:
       submit: '登録する'
       confirm: '確認する'
@@ -243,6 +267,9 @@ ja:
       show: '詳細'
       edit: '編集'
       delete: '削除'
+      grant_admin: '権限付与'
+      ensure_admin: '権限抹消'
+      back: '戻る'
   flash:
     permission_denied: 'アクセスが拒否されました'
     input_error: '入力に誤りがあります'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  get 'users/show'
+  namespace :admin do
+    get 'users/index'
+    get 'users/show'
+  end
   devise_for :users
 
   root to: 'spots#index'
@@ -12,8 +15,10 @@ Rails.application.routes.draw do
 
   resources :users, :only => [:show]
 
+  resources :admin, :only => [:index]
+
   namespace :admin do
-    resources :spots, only: [:new, :create, :edit, :update, :destroy] do
+    resources :spots, only: [:index, :new, :create, :edit, :update, :destroy] do
       collection do
         post :confirm
       end
@@ -21,6 +26,11 @@ Rails.application.routes.draw do
     resources :tags, only: [:index, :new, :create, :edit, :update, :destroy] do
       collection do
         post :confirm
+      end
+    end
+    resources :users, :only => [:index, :show, :new, :edit] do
+      member do
+        get :control
       end
     end
   end


### PR DESCRIPTION
#11 

更新内容
- 管理者メニューのページを追加した
- 管理者権限でUserとSpotのIndexページを見られるようにした
- 管理者メニューの各ページを日本語辞書ファイルに対応させた