### PR TITLE
スポット詳細ページのレイアウトを調整した

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,4 +1,6 @@
 class FavoritesController < ApplicationController
+  before_action :authenticate_user!
+
   def create
     favorite = current_user.favorites.create(spot_id: params[:spot_id])
     flash[:notice] = t('flash.favorited_spot')

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,6 +13,7 @@ import '../stylesheets/flash_message';
 import '../stylesheets/style';
 import '../stylesheets/top';
 import '../stylesheets/cards';
+import '../stylesheets/spot_show';
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/stylesheets/flash_message.css
+++ b/app/javascript/stylesheets/flash_message.css
@@ -2,7 +2,7 @@
   position: absolute;
   top: 5px;
   right: 5px;
-  z-index: 99;
+  z-index: 999;
 }
 
 .alert {

--- a/app/javascript/stylesheets/spot_show.css
+++ b/app/javascript/stylesheets/spot_show.css
@@ -1,0 +1,127 @@
+.show_title_area {
+  margin: 10px 0;
+  padding: 10px 0;
+}
+
+.show_title_area h1 {
+  letter-spacing: 0.2em;
+  font-weight: 600;
+  padding: 0 20px;
+}
+
+.show_key_visual {
+  width: 100%;
+  height: 300px;
+  padding: 0;
+  overflow: hidden;
+  display: block;
+}
+
+.show_key_visual img {
+	display: block;
+	width: 100%;
+  height: 300px;
+  padding: 0;
+	object-fit: cover;
+}
+
+.show_key_visual .copy{
+  position   : absolute;
+  display    : inline-block;
+  padding    : 10px;
+  background : rgba(0, 0, 0, 0.7);
+  color      : #fff;
+  bottom     : 10%;
+  right      : 3%;
+  z-index    : 11;
+}
+
+.show_key_visual .copy h3{
+  font-size: clamp(10px, 1.8vw, 20px);
+  font-weight: 600;
+  margin: 10px 0;
+  letter-spacing: 0.4em;
+}
+
+.show_sidebar {
+  position: sticky;
+  position: -webkit-sticky;
+  top: 0px;
+}
+
+.spot_basic_title h3 {
+  font-weight: 600;
+  line-height: 20px;
+  letter-spacing: 0.2em;
+  margin: 0;
+  vertical-align: middle;
+}
+
+.spot_basic_val {
+  letter-spacing: 0.1em;
+}
+
+
+
+.sidebar .area {
+  font-size: 2rem;
+  color: #FFF;
+  font-weight: 600;
+  letter-spacing: 0.4em;
+  text-align: center;
+}
+
+.fixed {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 50px;
+}
+
+/* 県北 */
+.sidebar .area-bg-1 {
+	background-color: #6AB26A !important;
+}
+
+/* 県央 */
+.sidebar .area-bg-2 {
+	background-color:#919aff !important;
+}
+
+/* 県西 */
+.sidebar .area-bg-3 {
+	background-color:#ffbc66 !important;
+}
+
+/* 県南 */
+.sidebar .area-bg-4 {
+	background-color:#ffafaf !important;
+}
+
+/* 鹿行 */
+.sidebar .area-bg-5 {
+	background-color:#87bdff  !important;
+}
+
+.fav-area {
+  font-size: 2rem;
+  text-align: center;
+}
+
+.show_map_area h4{
+  font-weight: 600;
+}
+
+.gmap_container {
+  height: 0;
+  overflow: hidden;
+  padding-bottom: 56.25%;
+  position: relative;
+}
+
+#gmap {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+}

--- a/app/javascript/stylesheets/spot_show.css
+++ b/app/javascript/stylesheets/spot_show.css
@@ -83,7 +83,10 @@
 
 .spot_description div figure img {
   margin-bottom: 10px;
-  max-width: 100%;
+  height: 150px;
+  width: 100%;
+  object-fit: contain;
+  background: #eee;
 }
 
 .sidebar .area {
@@ -130,8 +133,8 @@
   text-align: center;
 }
 
-
 .gmap_container {
+  margin: 15px auto 5px;
   height: 0;
   overflow: hidden;
   padding-bottom: 56.25%;

--- a/app/javascript/stylesheets/spot_show.css
+++ b/app/javascript/stylesheets/spot_show.css
@@ -61,7 +61,30 @@
   letter-spacing: 0.1em;
 }
 
+.spot_description p {
+  font-size: 1.4rem;
+	margin-bottom: 1.5rem;
+	line-height: 2.5rem;
+  letter-spacing: 1px;
+}
 
+.spot_description div figure {
+	margin: 10px 15px 0;
+	width: 40%;
+}
+
+.spot_description div:nth-child(even) figure {
+	float: right;
+}
+
+.spot_description div:nth-child(odd) figure {
+	float: left;
+}
+
+.spot_description div figure img {
+  margin-bottom: 10px;
+  max-width: 100%;
+}
 
 .sidebar .area {
   font-size: 2rem;
@@ -74,7 +97,7 @@
 .fixed {
   position: -webkit-sticky;
   position: sticky;
-  top: 50px;
+  top: 55px;
 }
 
 /* 県北 */
@@ -107,9 +130,6 @@
   text-align: center;
 }
 
-.show_map_area h4{
-  font-weight: 600;
-}
 
 .gmap_container {
   height: 0;

--- a/app/javascript/stylesheets/style.css
+++ b/app/javascript/stylesheets/style.css
@@ -7,11 +7,15 @@ body {
   height: 100%;
   font-size:1.6rem;
   line-height: 2;
+  /* background-color: #EFF9F9; */
   margin: 0 auto;
 }
 
 .main-wrapper {
-  margin-top: 20px;
+  margin:0 auto;
+  padding-top: 50px;
+  max-width: 1000px;
+  background-color: #FFF;
 }
 
 .title_area h2 {
@@ -64,12 +68,15 @@ body {
 }
 
 .header {
+  width: 100%;
   height: 50px;
   font-size: 0.9rem;
-  box-shadow: 0 5px 3px 0px rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid #cccccc;
   background-color: #ffffff;
-  position: relative;
-  z-index    : 20;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 20;
 }
 
 .logo-image {
@@ -106,7 +113,6 @@ body {
 .footer {
   width: 100%;
   height: auto;
-  margin-top: 20px;
   padding: 20px 0;
   background-color: #f5f5f5;
 	position:sticky;

--- a/app/javascript/stylesheets/style.css
+++ b/app/javascript/stylesheets/style.css
@@ -112,6 +112,7 @@ body {
 
 .footer {
   width: 100%;
+  margin-top: 30px;
   height: auto;
   padding: 20px 0;
   background-color: #f5f5f5;

--- a/app/views/layouts/_map.html.erb
+++ b/app/views/layouts/_map.html.erb
@@ -1,0 +1,25 @@
+<script>
+  let map
+
+  function initMap(){
+    geocoder = new google.maps.Geocoder()
+    var test ={lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>};
+
+    map = new google.maps.Map(document.getElementById("gmap"), {
+      center: test,
+      zoom: 9,
+    });
+
+    var contentString = "<%= @spot.address %>";
+    var infowindow = new google.maps.InfoWindow({
+      content: contentString
+    });
+
+    marker = new google.maps.Marker({
+      position:  test,
+      map: map,
+      title: contentString
+    });
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,9 @@
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.0/font/bootstrap-icons.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" type="text/javascript"></script>
+
   </head>
   <body>
     <%= render 'layouts/flash_message' %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, '茨城にちょっと行ってみたくなる :::ちょっくら茨城:::') %>
+<% content_for(:title, t('views.title.root')) %>
 <div class="key_visual_area">
   <%= image_tag '/assets/key_visual1.png', class: "key_image" %>
   <%= image_tag '/assets/key_visual2.jpg', class: "key_image"  %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, @spot.name) %>
-<div class="container mt-4">
+<div class="container my-4">
   <div class="row justify-content-center px-4">
     <div class="show_title_area area-<%= @spot.area_before_type_cast %> col-12">
       <h1><%= @spot.name %></h1>
@@ -12,7 +12,7 @@
         <h3><%= @spot.sales_copy %></h3>
       </div>
     </div>
-    <div class="col-12 col-md-4">
+    <div class="col-12 col-md-4 mb-5">
       <aside class="sidebar fixed border shadow-sm bg-white row p-0">
         <div class="area area-bg-<%= @spot.area_before_type_cast %> col-9 mb-2">
           <%= @spot.area %><%= t('views.messages.area') %>
@@ -35,19 +35,19 @@
           <h3><%= @spot.name %></h3>
         </div>
         <div class="spot_basic_attr col-12 py-1 px-2">
-          <h4><span class="badge bg-light"><%= t('activerecord.attributes.spot.address') %></span></h4>
+          <h3><span class="badge bg-light"><%= t('activerecord.attributes.spot.address') %></span></h3>
         </div>
         <div class="spot_basic_val col-12 py-1 px-4">
           <h4><%= @spot.address %></h4>
         </div>
         <div class="spot_basic_attr col-12 py-1 px-2">
-          <h4><span class="badge bg-light"><%= t('activerecord.attributes.spot.phone') %></span></h4>
+          <h3><span class="badge bg-light"><%= t('activerecord.attributes.spot.phone') %></span></h3>
         </div>
         <div class="spot_basic_val col-12 py-1 px-4">
           <h4><%= @spot.phone %></h4>
         </div>
         <div class="spot_basic_attr col-12 py-1 px-2">
-          <h4><span class="badge bg-light"><%= t('activerecord.attributes.spot.holiday') %></span></h4>
+          <h3><span class="badge bg-light"><%= t('activerecord.attributes.spot.holiday') %></span></h3>
         </div>
         <div class="spot_basic_val col-12 py-1 px-4">
           <h4><%= @spot.holiday %></h4>
@@ -64,13 +64,41 @@
         </div>
       </aside>
     </div>
-    <div class="main col-12 col-md-8 pl-4 pr-0">
+    <div class="main col-12 col-md-8 pl-0 pl-md-4 pr-0">
       <main>
-        <article class="border shadow-sm bg-white">
-          <%= @spot.detail_description %>
+        <%# 記事部分 %>
+        <article class="border shadow-sm bg-white p-4">
+          <h3><span class="badge bg-light"><%= t('views.messages.spot_overview') %></span></h3>
+          <div class="spot_description">
+            <div class="my-3 clearfix">
+              <% if @spot.images.second && @spot.images.second.url %>
+                <figure>
+                  <%= link_to @spot.images.second.url, "data-lightbox": @spot.images.second do %>
+                    <%= image_tag(@spot.images.second.url) %>
+                  <% end %>
+                </figure>
+              <% end %>
+              <p>
+                <%= @spot.detail_description %>
+              </p>
+            </div>
+            <div class="my-5 clearfix">
+              <% if @spot.images.third && @spot.images.third.url %>
+                <figure>
+                  <%= link_to @spot.images.third.url, "data-lightbox": @spot.images.third do %>
+                    <%= image_tag(@spot.images.third.url) %>
+                  <% end %>
+                </figure>
+              <% end %>
+              <p>
+                <%= @spot.detail_description %>
+              </p>
+            </div>
+          </div>
         </article>
-        <div class="show_map_area border shadow-sm bg-white mt-3">
-          <h4>地図情報</h4>
+        <%# 地図部分 %>
+        <div class="show_map_area border shadow-sm bg-white mt-5 p-4">
+          <h3><span class="badge bg-light"><%= t('views.messages.map_info') %></span></h3>
           <div class="gmap_container">
             <div id="gmap"></div>
           </div>
@@ -79,39 +107,4 @@
     </div>
   </div>
 </div>
-
-
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<br />
-<hr>
-<div class="shadow-sm bg-white rounded row no-gutters col-12 mb-4">
-  <% @spot.images.each do |image| %>
-    <% if image && image.url %>
-      <%= image_tag(image.url, style: "max-width: 100px; max-height: 100px;") %>
-    <% end %>
-  <% end %>
-</div>
-  <%#  地図読み込み
 <%= render 'layouts/map' %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -34,39 +34,40 @@
         <div class="spot_basic_title col-12 py-4 px-3">
           <h3><%= @spot.name %></h3>
         </div>
-        <div class="spot_basic_attr col-12 py-1 px-2">
+        <div class="spot_basic_attr col-12 py-1 px-3">
           <h3><span class="badge bg-light"><%= t('activerecord.attributes.spot.address') %></span></h3>
         </div>
-        <div class="spot_basic_val col-12 py-1 px-4">
+        <div class="spot_basic_val col-12 py-1 px-5">
           <h4><%= @spot.address %></h4>
         </div>
-        <div class="spot_basic_attr col-12 py-1 px-2">
+        <div class="spot_basic_attr col-12 py-1 px-3">
           <h3><span class="badge bg-light"><%= t('activerecord.attributes.spot.phone') %></span></h3>
         </div>
-        <div class="spot_basic_val col-12 py-1 px-4">
+        <div class="spot_basic_val col-12 py-1 px-5">
           <h4><%= @spot.phone %></h4>
         </div>
-        <div class="spot_basic_attr col-12 py-1 px-2">
+        <div class="spot_basic_attr col-12 py-1 px-3">
           <h3><span class="badge bg-light"><%= t('activerecord.attributes.spot.holiday') %></span></h3>
         </div>
-        <div class="spot_basic_val col-12 py-1 px-4">
+        <div class="spot_basic_val col-12 py-1 px-5">
           <h4><%= @spot.holiday %></h4>
         </div>
-        <div>
-          <ul>
-            <% if user_signed_in? %>
-              <% if current_user.try(:admin?) %>
-                <li><%= link_to "編集", edit_admin_spot_path %></li>
-                <li><%= link_to "削除", admin_spot_path(@spot.id), method: :delete, data: { confirm: '本当に削除しますか？' } %></li>
-              <% end %>
-            <% end %>
-          </ul>
-        </div>
+        <%# 管理メニュー %>
+        <% if user_signed_in? %>
+          <% if current_user.try(:admin?) %>
+            <div class="border-top col-12 mt-4 py-1 px-4">
+              <h3 class="py-3"><span class="badge text-white bg-info"><%= t('views.messages.admin_menu') %></span></h3>
+              <ul>
+                <li><%= link_to t('views.button.edit'), edit_admin_spot_path %></li>
+                <li><%= link_to t('views.button.delete'), admin_spot_path(@spot.id), method: :delete, data: { confirm: '本当に削除しますか？' } %></li>
+              </ul>
+            </div>
+          <% end %>
+        <% end %>
       </aside>
     </div>
     <div class="main col-12 col-md-8 pl-0 pl-md-4 pr-0">
       <main>
-        <%# 記事部分 %>
         <article class="border shadow-sm bg-white p-4">
           <h3><span class="badge bg-light"><%= t('views.messages.spot_overview') %></span></h3>
           <div class="spot_description">
@@ -96,7 +97,6 @@
             </div>
           </div>
         </article>
-        <%# 地図部分 %>
         <div class="show_map_area border shadow-sm bg-white mt-5 p-4">
           <h3><span class="badge bg-light"><%= t('views.messages.map_info') %></span></h3>
           <div class="gmap_container">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,86 +1,117 @@
 <% content_for(:title, @spot.name) %>
-
-<div>
-<h4><%= @spot.name %></h4>
+<div class="container mt-4">
+  <div class="row justify-content-center px-4">
+    <div class="show_title_area area-<%= @spot.area_before_type_cast %> col-12">
+      <h1><%= @spot.name %></h1>
+    </div>
+    <div class="show_key_visual col-12 mb-5">
+      <% if @spot.images.first && @spot.images.first.url %>
+        <%= image_tag(@spot.images.first.url) %>
+      <% end %>
+      <div class="copy">
+        <h3><%= @spot.sales_copy %></h3>
+      </div>
+    </div>
+    <div class="col-12 col-md-4">
+      <aside class="sidebar fixed border shadow-sm bg-white row p-0">
+        <div class="area area-bg-<%= @spot.area_before_type_cast %> col-9 mb-2">
+          <%= @spot.area %><%= t('views.messages.area') %>
+        </div>
+        <div class="col-3 fav-area">
+          <% if user_signed_in? %>
+            <% if @spot.favorited_by?(current_user)  %>
+              <%= link_to favorite_path(@spot), method: :delete do %>
+                <span class="bi bi-heart-fill" title="<%= t('views.messages.remove_favorite') %>"></span><% end %>
+            <% else %>
+              <%= link_to favorites_path(spot_id: @spot.id), method: :post do %>
+                <span class="bi bi-heart" title="<%= t('views.messages.add_favorite') %>"></span><% end %>
+            <% end %>
+          <% else %>
+            <%= link_to new_user_session_path do %>
+              <span class="bi bi-heart" title="<%= t('views.messages.add_favorite') %>"></span><% end %>
+          <% end %>
+        </div>
+        <div class="spot_basic_title col-12 py-4 px-3">
+          <h3><%= @spot.name %></h3>
+        </div>
+        <div class="spot_basic_attr col-12 py-1 px-2">
+          <h4><span class="badge bg-light"><%= t('activerecord.attributes.spot.address') %></span></h4>
+        </div>
+        <div class="spot_basic_val col-12 py-1 px-4">
+          <h4><%= @spot.address %></h4>
+        </div>
+        <div class="spot_basic_attr col-12 py-1 px-2">
+          <h4><span class="badge bg-light"><%= t('activerecord.attributes.spot.phone') %></span></h4>
+        </div>
+        <div class="spot_basic_val col-12 py-1 px-4">
+          <h4><%= @spot.phone %></h4>
+        </div>
+        <div class="spot_basic_attr col-12 py-1 px-2">
+          <h4><span class="badge bg-light"><%= t('activerecord.attributes.spot.holiday') %></span></h4>
+        </div>
+        <div class="spot_basic_val col-12 py-1 px-4">
+          <h4><%= @spot.holiday %></h4>
+        </div>
+        <div>
+          <ul>
+            <% if user_signed_in? %>
+              <% if current_user.try(:admin?) %>
+                <li><%= link_to "編集", edit_admin_spot_path %></li>
+                <li><%= link_to "削除", admin_spot_path(@spot.id), method: :delete, data: { confirm: '本当に削除しますか？' } %></li>
+              <% end %>
+            <% end %>
+          </ul>
+        </div>
+      </aside>
+    </div>
+    <div class="main col-12 col-md-8 pl-4 pr-0">
+      <main>
+        <article class="border shadow-sm bg-white">
+          <%= @spot.detail_description %>
+        </article>
+        <div class="show_map_area border shadow-sm bg-white mt-3">
+          <h4>地図情報</h4>
+          <div class="gmap_container">
+            <div id="gmap"></div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
 </div>
 
 
-
-
-
-
-
-
-
-
-
-
-<div>
-  <h4><%= @spot.name %></h4>
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<hr>
+<div class="shadow-sm bg-white rounded row no-gutters col-12 mb-4">
   <% @spot.images.each do |image| %>
     <% if image && image.url %>
       <%= image_tag(image.url, style: "max-width: 100px; max-height: 100px;") %>
     <% end %>
   <% end %>
 </div>
-<div>
-<div id='map'></div>
-
-<style>
-#map {
-  height: 300px;
-  width: 400px;
-}
-</style>
-
-<script>
-  let map
-
-  function initMap(){
-    geocoder = new google.maps.Geocoder()
-    var test ={lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>};
-
-    map = new google.maps.Map(document.getElementById('map'), {
-      center: test,
-      zoom: 15,
-    });
-
-    var contentString = '<%= @spot.address %>';
-    var infowindow = new google.maps.InfoWindow({
-      content: contentString
-    });
-
-    marker = new google.maps.Marker({
-      position:  test,
-      map: map,
-      title: contentString
-    });
-  }
-</script>
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>
-
-
-
-</div>
-<div>
-  <%= @spot.address %><br />
-  <%= @spot.phone %><br />
-  <%= @spot.holiday %><br />
-<% if current_user%>
-  <% if @spot.favorited_by?(current_user)  %>
-    <%= link_to 'お気に入り解除する', favorite_path(@spot), method: :delete, class: 'btn btn-danger' %>
-  <% else %>
-    <%= link_to 'お気に入りする', favorites_path(spot_id: @spot.id), method: :post, class: 'btn btn-primary' %>
-  <% end %>
-<%end%>
-<%= link_to 'Back', spots_path %>
-<div>
-  <ul>
-    <% if user_signed_in? %>
-      <% if current_user.try(:admin?) %>
-        <li><%= link_to "編集", edit_admin_spot_path %></li>
-        <li><%= link_to "削除", admin_spot_path(@spot.id), method: :delete, data: { confirm: '本当に削除しますか？' } %></li>
-      <% end %>
-    <% end %>
-  </ul>
-</div>
+  <%#  地図読み込み
+<%= render 'layouts/map' %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -260,7 +260,7 @@ ja:
       control: '操作'
       back: '戻る'
       select_tag: "タグを選択する"
-      add_favorite: "お気に入りを解除する"
+      add_favorite: "お気に入りに登録する"
       remove_favorite: "お気に入りを解除する"
       grant_admin: "管理者権限を付与しました"
       ensure_admin: "管理者権限を抹消しました"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -231,6 +231,8 @@ ja:
       short: "%m/%d %H:%M"
     pm: 午後
   views:
+    title:
+      root: "茨城にちょっと行ってみたくなる -ちょっくら茨城-"
     messages:
       key_title: "いばらき、いちど来てみで！"
       key_text_html: "海、山、湖、自然あふれる場所。<br />都心からでも思い立ったらすぐ行けます。<br />ちょっとしたお出かけ気分で行ってみませんか？"
@@ -265,6 +267,7 @@ ja:
       already_admin: "すでに管理者権限があります"
       already_not_admin: "すでに管理者権限はありません"
       change_admin_failed: "管理者権限の変更に失敗しました"
+      area: "エリア"
     button:
       submit: '登録する'
       confirm: '確認する'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -267,7 +267,9 @@ ja:
       already_admin: "すでに管理者権限があります"
       already_not_admin: "すでに管理者権限はありません"
       change_admin_failed: "管理者権限の変更に失敗しました"
+      spot_overview: "スポット概要"
       area: "エリア"
+      map_info: "地図情報"
     button:
       submit: '登録する'
       confirm: '確認する'

--- a/db/migrate/20230618161852_change_column_default_to_spots.rb
+++ b/db/migrate/20230618161852_change_column_default_to_spots.rb
@@ -1,0 +1,6 @@
+class ChangeColumnDefaultToSpots < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :spots, :phone, from: nil, to: "未掲載"
+    change_column_default :spots, :holiday, from: nil, to: "未掲載"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_15_114415) do
+ActiveRecord::Schema.define(version: 2023_06_18_161852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,8 +29,8 @@ ActiveRecord::Schema.define(version: 2023_06_15_114415) do
     t.json "images"
     t.integer "area", null: false
     t.string "address", null: false
-    t.string "phone"
-    t.string "holiday"
+    t.string "phone", default: "未掲載"
+    t.string "holiday", default: "未掲載"
     t.string "sales_copy"
     t.text "detail_description", null: false
     t.string "simple_description"


### PR DESCRIPTION
#15 

更新内容
- スポット詳細ページにキービジュアルとキャッチコピーを表示するようにした
- スポット詳細ページに所在エリアを表示する際にイメージカラーの背景色を付けるようにした
- スポット詳細ページにGoogleMapによる地図情報を表示した
- スポット詳細ページのスポット概要に配置する写真をクリックすると拡大表示されるようにした
- スポット詳細ページにお気入りボタンを配置した
- 管理者権限でログイン中、スポット詳細ページにスポット編集と削除のリンクを表示するようにした
- フッターを用意した