### PR TITLE
所在エリアでスポットの絞り込みをできるようにした

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -6,10 +6,15 @@ class SpotsController < ApplicationController
 
   def search
     @spots = Spot.all
-    key_tag_id = params[:key_tag_id]
+    area = params[:area]
+    tag_id = params[:tag_id]
 
-    if key_tag_id.present?
-      @spots = @spots.tag_search(key_tag_id.to_i)
+    if area.present?
+      @spots = @spots.area_search(area)
+    end
+
+    if tag_id.present?
+      @spots = @spots.tag_search(tag_id.to_i)
     end
 
     #pagination

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,10 +1,5 @@
-// This file is automatically compiled by Webpack, along with any other files
-// present in this directory. You're encouraged to place your actual application logic in
-// a relevant structure within app/javascript and only use these pack files to reference
-// that code so it'll be compiled.
-
 import Rails from "@rails/ujs"
-import Turbolinks from "turbolinks"
+// import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 import 'bootstrap';
@@ -16,10 +11,10 @@ import '../stylesheets/cards';
 import '../stylesheets/spot_show';
 
 Rails.start()
-Turbolinks.start()
+// Turbolinks.start()
 ActiveStorage.start()
 
-$(document).on ("turbolinks:load", function(){
+$(function(){
   setTimeout(function () {
     $("#flash_msg").hide();
   }, 3000);

--- a/app/javascript/stylesheets/spot_show.css
+++ b/app/javascript/stylesheets/spot_show.css
@@ -133,6 +133,11 @@
   text-align: center;
 }
 
+.fav-area span{
+  vertical-align: middle;
+}
+
+
 .gmap_container {
   margin: 15px auto 5px;
   height: 0;

--- a/app/javascript/stylesheets/top.css
+++ b/app/javascript/stylesheets/top.css
@@ -59,24 +59,12 @@
 	100%{ opacity: 0;}
 }
 
-.spot_index_header {
-  margin: 0 0 30px;
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-}
-
 .spot_index_header img {
-  width: 28%;
+  width: 250px;
   height: auto;
-}
-
-.spot_search_area {
-  float: right;
 }
 
 .spot_search_area div {
   float: left;
   display: flex;
-  align-items: flex-end;
 }

--- a/app/javascript/stylesheets/top.css
+++ b/app/javascript/stylesheets/top.css
@@ -59,9 +59,17 @@
 	100%{ opacity: 0;}
 }
 
-.spot_index_header img {
+.spot_index_header {
+  background-color: #fff;
+}
+
+.spots_title img {
   width: 250px;
   height: auto;
+}
+
+.spot_search_area {
+  z-index: 50;
 }
 
 .spot_search_area div {

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -23,5 +23,6 @@ class Spot < ApplicationRecord
     favorites.where(user_id: user.id).exists?
   end
 
-  scope :tag_search, -> (key_tag_id){ where(id: Tagging.where(tag_id: key_tag_id).pluck(:spot_id)) }
+  scope :area_search, -> (area){ where(area: area) }
+  scope :tag_search, -> (tag_id){ where(id: Tagging.where(tag_id: tag_id).pluck(:spot_id)) }
 end

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -9,24 +9,30 @@
     <span><%= t('views.messages.key_text_html') %></span>
   </div>
 </div>
-<div class="container mt-4">
-  <div class="p-0 spot_index_header">
-    <%= image_tag '/assets/spot_title.jpg' %>
-    <div class="spot_search_area row">
-      <%= form_with url: search_spots_path, method: :get, local: true do |f| %>
-        <div class="col-auto">
-          <%= f.select :key_tag_id, Tag.all.collect { |l| ["#{l.name}(#{l.spots.count})", l.id] }, { include_blank: t('views.messages.select_tag'), selected: params[:key_tag_id] }, class:"form-control-lg", value: @key_tag_id  %>
-        </div>
-        <div class="col-auto pl-1">
-          <%= f.submit t('views.button.search'), class:"form-control form-control-lg" %>
-        </div>
-      <% end %>
+<div class="container mt-4 p-0">
+  <div class="p-0 my-4 spot_index_header row">
+    <div class="col-12 col-md-6 col-lg-7  p-0">
+      <%= image_tag '/assets/spot_title.jpg' %>
+    </div>
+    <div class="spot_search_area col-12 col-md-6 col-lg-5 py-4 p-md-0">
+      <div class="search_bar shadow-sm py-4 px-2 w-100 w-md-50 justify-content-center">
+        <%= form_with url: search_spots_path, method: :get, local: true do |f| %>
+          <div class="col-auto p-0">
+            <%= f.select :area, Spot.areas.keys, { include_blank: "エリアを選択する" }, value: @area, class: "form-control form-control-lg"  %>
+            <%= f.select :tag_id, Tag.all.collect { |tag| ["#{tag.name}(#{tag.spots.count})", tag.id] }, { include_blank: t('views.messages.select_tag'), selected: params[:tag_id] }, class:"form-control form-control-lg ml-3", value: @tag_id  %>
+          </div>
+          <div class="col-auto pl-2 pr-0">
+            <%= f.submit t('views.button.search'), class:"form-control form-control-lg" %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
   <% if @spots.empty? %>
     <div class="row justify-content-center">
       <div class="empty-wrapper">
         <%= image_tag '/assets/no_spot.png', class: 'no-image' %>
+
       </div>
     </div>
   <% else %>
@@ -65,7 +71,7 @@
               <div class="place-card__tags">
                 <p class="mb-0 text-muted">
                   <% spot.tags.each_with_index do |tag, index| %>
-                    <%= link_to tag.name, search_spots_path(key_tag_id: tag.id) %>
+                    <%= link_to tag.name, search_spots_path(tag_id: tag.id) %>
                     <%= ',' unless index == spot.tags.size - 1 %>
                   <% end %>
                 </p>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -9,34 +9,31 @@
     <span><%= t('views.messages.key_text_html') %></span>
   </div>
 </div>
-<div class="container mt-4 p-0">
-  <div class="p-0 my-4 spot_index_header row">
-    <div class="col-12 col-md-6 col-lg-7  p-0">
-      <%= image_tag '/assets/spot_title.jpg' %>
-    </div>
-    <div class="spot_search_area col-12 col-md-6 col-lg-5 py-4 p-md-0">
-      <div class="search_bar shadow-sm py-4 px-2 w-100 w-md-50 justify-content-center">
-        <%= form_with url: search_spots_path, method: :get, local: true do |f| %>
-          <div class="col-auto p-0">
-            <%= f.select :area, Spot.areas.keys, { include_blank: "エリアを選択する" }, value: @area, class: "form-control form-control-lg"  %>
-            <%= f.select :tag_id, Tag.all.collect { |tag| ["#{tag.name}(#{tag.spots.count})", tag.id] }, { include_blank: t('views.messages.select_tag'), selected: params[:tag_id] }, class:"form-control form-control-lg ml-3", value: @tag_id  %>
-          </div>
-          <div class="col-auto pl-2 pr-0">
-            <%= f.submit t('views.button.search'), class:"form-control form-control-lg" %>
-          </div>
-        <% end %>
-      </div>
+<div class="container row mt-4 mx-auto p-2 justify-content-center">
+  <div class="spots_title col-12 col-md-5 col-lg-7 py-0 mb-4 px-4">
+    <%= image_tag '/assets/spot_title.jpg' %>
+  </div>
+  <div class="spot_search_area fixed col-12 col-md-7 col-lg-5 mb-4">
+    <div class="search_bar shadow bg-white rounded py-4 px-2 w-100 w-md-50 justify-content-center">
+      <%= form_with url: search_spots_path, method: :get, local: true do |f| %>
+        <div class="col-auto p-0">
+          <%= f.select :area, Spot.areas.keys, { include_blank: t('views.messages.select_area'), selected: params[:area] }, value: @area, class: "form-control form-control-lg" %>
+          <%= f.select :tag_id, Tag.all.collect { |tag| ["#{tag.name}(#{tag.spots.count})", tag.id] }, { include_blank: t('views.messages.select_tag'), selected: params[:tag_id] }, value: @tag_id, class:"form-control form-control-lg ml-3" %>
+        </div>
+        <div class="col-auto pl-2 pr-0">
+          <%= f.submit t('views.button.search'), class:"form-control form-control-lg" %>
+        </div>
+      <% end %>
     </div>
   </div>
   <% if @spots.empty? %>
-    <div class="row justify-content-center">
+    <div class="row justify-content-center col-12">
       <div class="empty-wrapper">
         <%= image_tag '/assets/no_spot.png', class: 'no-image' %>
-
       </div>
     </div>
   <% else %>
-    <div class="row justify-content-start">
+    <div class="row justify-content-start col-12">
       <% @spots.each do |spot| %>
         <div class="col-12 col-md-6 col-lg-4">
           <div class="place-card__header">

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -17,8 +17,8 @@
     <div class="search_bar shadow bg-white rounded py-4 px-2 w-100 w-md-50 justify-content-center">
       <%= form_with url: search_spots_path, method: :get, local: true do |f| %>
         <div class="col-auto p-0">
-          <%= f.select :area, Spot.areas.keys, { include_blank: t('views.messages.select_area'), selected: params[:area] }, value: @area, class: "form-control form-control-lg" %>
-          <%= f.select :tag_id, Tag.all.collect { |tag| ["#{tag.name}(#{tag.spots.count})", tag.id] }, { include_blank: t('views.messages.select_tag'), selected: params[:tag_id] }, value: @tag_id, class:"form-control form-control-lg ml-3" %>
+          <%= f.select :area, Spot.areas.keys.map { |area| [area + "(#{Spot.where(area: area).count})", area] }, { include_blank: t('views.messages.select_area'), selected: params[:area] }, value: @area, class: "form-control form-control-lg" %>
+          <%= f.select :tag_id, Tag.all.collect { |tag| [tag.name + "(#{tag.spots.count})", tag.id] }, { include_blank: t('views.messages.select_tag'), selected: params[:tag_id] }, value: @tag_id, class:"form-control form-control-lg ml-3" %>
         </div>
         <div class="col-auto pl-2 pr-0">
           <%= f.submit t('views.button.search'), class:"form-control form-control-lg" %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -52,10 +52,10 @@
         <div class="spot_basic_val col-12 py-1 px-5">
           <h4><%= @spot.holiday %></h4>
         </div>
-        <%# 管理メニュー %>
+        <%# ===Admin Only=== %>
         <% if user_signed_in? %>
           <% if current_user.try(:admin?) %>
-            <div class="border-top col-12 mt-4 py-1 px-4">
+            <div class="border-top col-12 mt-4 pt-2 px-4">
               <h3 class="py-3"><span class="badge text-white bg-info"><%= t('views.messages.admin_menu') %></span></h3>
               <ul>
                 <li><%= link_to t('views.button.edit'), edit_admin_spot_path %></li>
@@ -64,6 +64,7 @@
             </div>
           <% end %>
         <% end %>
+        <%# ===Admin Only=== %>
       </aside>
     </div>
     <div class="main col-12 col-md-8 pl-0 pl-md-4 pr-0">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -13,7 +13,7 @@
       </div>
     </div>
     <div class="col-12 col-md-4 mb-5">
-      <aside class="sidebar fixed border shadow-sm bg-white row p-0">
+      <aside class="sidebar fixed border shadow-sm bg-white row pb-2">
         <div class="area area-bg-<%= @spot.area_before_type_cast %> col-9 mb-2">
           <%= @spot.area %><%= t('views.messages.area') %>
         </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -259,7 +259,7 @@ ja:
       logout: 'ログアウト'
       control: '操作'
       back: '戻る'
-      select_tag: "タグを選択する"
+      select_tag: "タグの選択"
       add_favorite: "お気に入りに登録する"
       remove_favorite: "お気に入りを解除する"
       grant_admin: "管理者権限を付与しました"


### PR DESCRIPTION
#17 

更新内容
- Spotモデルにエリアでの絞り込みのためのスコープを実装した
- トップページでエリアのデータを使ってスポットの絞り込みができるようにした
- トップページの検索フォームを下へのスクロール時に追従するようにした