### PR TITLE
一部のデザインを修正した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,3 +44,6 @@ gem 'devise'
 gem 'devise-i18n'
 gem "geocoder"
 gem "dotenv-rails"
+gem 'net-smtp'
+gem 'net-imap'
+gem 'net-pop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,6 @@ GEM
     geocoder (1.8.1)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    gmaps4rails (2.1.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -162,6 +161,8 @@ GEM
       net-protocol
     nio4r (2.5.9)
     nokogiri (1.15.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.2-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.5.3)
@@ -292,6 +293,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
@@ -305,12 +307,14 @@ DEPENDENCIES
   factory_bot_rails
   faker
   geocoder
-  gmaps4rails
   jbuilder (~> 2.7)
   launchy
   letter_opener_web
   listen (~> 3.3)
   mini_magick
+  net-imap
+  net-pop
+  net-smtp
   pg (~> 1.1)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,5 +2,5 @@ class Tag < ApplicationRecord
   has_many :taggings, dependent: :destroy
   has_many :spots, through: :taggings
 
-  validates :name, uniqueness: true
+  validates :name,  presence: true, uniqueness: true
 end

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -17,7 +17,7 @@
   <div class="form-group shadow px-3 py-4 mb-5 mx-auto bg-white w-100 rounded justify-content-center">
     <div class="field py-2">
       <%= f.label :name, class:"badge" %>
-      <%= f.text_field :name, size: 54, placeholder:t('activerecord.attributes.tag.name'), class:"input-font form-control input-font form-control-lg" %>
+      <%= f.text_field :name, size: 54, placeholder:t('views.form_supplement.tag_name'), class:"input-font form-control input-font form-control-lg" %>
     </div>
     <div class="actions mt-3 pt-4 border-top">
       <%= f.submit t('views.button.confirm'), class:"w-75 mx-auto btn-primary input-font form-control input-font form-control-lg" %>

--- a/app/views/admin/tags/confirm.html.erb
+++ b/app/views/admin/tags/confirm.html.erb
@@ -1,15 +1,41 @@
-<% content_for(:title, "確認") %>
-<h2>Confirm</h2>
-<%= form_with(model: @tag, local: true, url: admin_tags_path ) do |f| %>
-  <%= f.hidden_field :name %>
-  <div>Name: <%= @tag.name %></div>
-  <div>
-    <%= f.submit "登録" %>
+<div class="form-wrapper">
+  <div class="container justify-content-center">
+    <div class="title_area">
+      <h2><%= t('views.title.confirm_page') %></h2>
+    </div>
+    <div>
+      <% content_for(:title, t('views.title.confirm_page')) %>
+      <%= form_with(model: @tag, local: true, url: admin_tags_path ) do |f| %>
+        <div class="w-100 mx-auto my-4">
+          <% if @tag.errors.any? %>
+            <div class="form-error-message shadow">
+              <h5 class="alert-heading"><%= t('errors.messages.title') %></h5>
+              <div>
+                <ul>
+                  <% @tag.errors.full_messages.each do |message| %>
+                    <li><%= message %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+          <% end %>
+        </div>
+        <div class="form-group shadow px-3 py-4 mb-5 mx-auto bg-white w-100 rounded justify-content-center">
+          <div class="field py-2">
+            <%= f.label :name, class:"badge" %>
+            <div class="w-100 pl-5 py-1"><%= @tag.name %></div>
+          </div>
+          <div class="actions mt-3 pt-4 border-top">
+            <%= f.submit t('views.button.submit'), class:"w-75 mx-auto btn-primary input-font form-control input-font form-control-lg" %>
+          </div>
+        </div>
+      <% end %>
+      <%= form_with(model: @tag, url:new_admin_tag_path, local:true, method:"get") do |f| %>
+        <%= f.hidden_field :name %>
+        <div>
+          <%= f.submit t('views.button.back'), class:"w-25 mx-auto btn-secondary input-font form-control form-control-lg", name: 'back' %>
+        </div>
+      <% end %>
+    </div>
   </div>
-<% end %>
-<%= form_with(model: @tag, url:new_admin_tag_path, local:true, method:"get") do |f| %>
-  <%= f.hidden_field :name %>
-  <div>
-    <%= f.submit "戻る", name: 'back' %>
-  </div>
-<% end %>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <header class="header clearfix">
   <%= link_to root_path do %>
-    <%= image_tag '/assets/title_logo.png', class: 'logo-image' %>
+    <%= image_tag 'title_logo.png', class: 'logo-image' %>
   <% end %>
   <div class="top_menu clearfix">
     <ul>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:title, t('views.title.root')) %>
 <div class="spot_index_wrapper">
   <div class="key_visual_area">
-    <%= image_tag '/assets/key_visual1.png', class: "key_image" %>
-    <%= image_tag '/assets/key_visual2.jpg', class: "key_image"  %>
-    <%= image_tag '/assets/key_visual3.jpg', class: "key_image"  %>
-    <%= image_tag '/assets/key_visual4.png', class: "key_image"  %>
+    <%= image_tag 'key_visual1.png', class: "key_image" %>
+    <%= image_tag 'key_visual2.jpg', class: "key_image"  %>
+    <%= image_tag 'key_visual3.jpg', class: "key_image"  %>
+    <%= image_tag 'key_visual4.png', class: "key_image"  %>
     <div class="copy">
       <h4><%= t('views.messages.key_title') %></h4>
       <span><%= t('views.messages.key_text_html') %></span>
@@ -12,7 +12,7 @@
   </div>
   <div class="container row mt-4 mx-auto p-2 justify-content-center">
     <div class="spots_title col-12 col-md-5 col-lg-7 py-0 mb-4 px-4">
-      <%= image_tag '/assets/spot_title.jpg' %>
+      <%= image_tag 'spot_title.jpg' %>
     </div>
     <div class="spot_search_area fixed col-12 col-md-7 col-lg-5 mb-4">
       <div class="search_bar shadow bg-white rounded py-4 px-2 w-100 w-md-50 justify-content-center">
@@ -30,7 +30,7 @@
     <% if @spots.empty? %>
       <div class="row justify-content-center col-12">
         <div class="empty-wrapper">
-          <%= image_tag '/assets/no_spot.png', class: 'no-image' %>
+          <%= image_tag 'no_spot.png', class: 'no-image' %>
         </div>
       </div>
     <% else %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -46,6 +46,8 @@
                   <%= link_to spot_path(spot.id) do %>
                     <%= image_tag(spot.images.first.url) %>
                   <% end %>
+                <% else %>
+                  <%= image_tag 'no_spot.png' %>
                 <% end %>
               </div>
               <div class="place-card__content">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -65,10 +65,10 @@
               <% end %>
             </div>
             <div class="col-12 p-0 admin-btn">
-              <%= link_to admin_spot_path(@spot.id), method: :delete, data: { confirm: '本当に削除しますか？' }  do %>
+              <%= link_to admin_spot_path(@spot.id), method: :delete, data: { confirm: t('views.messages.want_to_delete?') }  do %>
                 <div class="admin-item-sm border text-white m-1">
                   <span class="bi bi-trash"></span>
-                  <h3><%= t('views.admin_menus.watch_users') %></h3>
+                  <h3><%= t('views.admin_menus.delete_spot') %></h3>
                 </div>
               <% end %>
             </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -291,6 +291,7 @@ ja:
       sales_copy: "詳細ページのキービジュアルで使用するコピーを入力します。"
       detail_description: "詳細ページのスポット説明で使用する説明文を入力します。"
       simple_description: "トップページのスポット説明で使用する説明文を入力します。"
+      tag_name: "タグの名称を入力します。"
     button:
       submit: '登録する'
       confirm: '確認する'

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "sass": "1.32.12"
   },
   "resolutions": {
-      "sass": "1.32.12"
+    "sass": "1.32.12"
+  },"engines": {
+    "node": "16.x"
   }
 }


### PR DESCRIPTION
#21 

更新内容
- スポット詳細ページの削除ボタンのテキストを修正する
- タグ登録フォームのプレースホルダーを修正する
- タグの確認画面のレイアウトを登録フォームに合わせる