### PR TITLE
[修正]タグ登録の確認画面のバグを修正した

### DIFF
--- a/app/views/admin/tags/confirm.html.erb
+++ b/app/views/admin/tags/confirm.html.erb
@@ -6,6 +6,7 @@
     <div>
       <% content_for(:title, t('views.title.confirm_page')) %>
       <%= form_with(model: @tag, local: true, url: admin_tags_path ) do |f| %>
+        <%= f.hidden_field :name %>
         <div class="form-group shadow px-3 py-4 mb-5 mx-auto bg-white w-100 rounded justify-content-center">
           <div class="field py-2">
             <%= f.label :name, class:"badge" %>


### PR DESCRIPTION
更新内容
- タグの登録時にコントローラーで値が受け取れないバグを修正した